### PR TITLE
Bump dependencies and update project version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unified-sources"
-version = "0.1.2"
+version = "0.1.3"
 description = "DLT sources for Unified Reporting"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -10,5 +10,5 @@ dependencies = [
 
 [dependency-groups]
 seznam-sklik = [
-    "sklik>=1.0.5",
+    "sklik>=1.0.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -370,9 +370,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/69/831ed22b38ff9b4b64b66569f0e5b7b97cf3638346eb95a2147fdb49ad5f/pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7", size = 444229, upload-time = "2025-05-22T21:18:06.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
 [[package]]
@@ -602,16 +602,16 @@ wheels = [
 
 [[package]]
 name = "sklik"
-version = "1.0.5"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pendulum" },
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/d5/b06ee3aac7fa83dfc5d9eb367206f947e336db3bfe8c2530ba3ad823daec/sklik-1.0.5.tar.gz", hash = "sha256:8b36ac8a82b9be271caa8ba326e1b8aec1a740f68b7bc98eaed568f2f4967409", size = 49289, upload-time = "2025-05-18T15:49:48.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/47/f91908a7b90e8b7d1eae50f69c637a7512b5478084ef6eafb446de67e2e5/sklik-1.0.6.tar.gz", hash = "sha256:a903aa410f0b491c525b32373f0b97a2236ca359eacbc30d4c6205aae62c1a06", size = 71599, upload-time = "2025-07-16T15:54:21.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/18/1f6a6e2fc7991b0f78de905575b38ef927271a9bbb86e5972c132c2009a3/sklik-1.0.5-py3-none-any.whl", hash = "sha256:54249de12bb69a0fa3fad102a478c6164435345109caa86a67918d36449df7a5", size = 10915, upload-time = "2025-05-18T15:49:46.757Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/48/bac022efa4a0fdf8566fc804307cc1778671b2c27dfdebe0a45dba80ea1a/sklik-1.0.6-py3-none-any.whl", hash = "sha256:268caba07f738a1cadb47b061ee09ef53a69662d9ebeb8db94986b0d7f552b07", size = 11650, upload-time = "2025-07-16T15:54:20.497Z" },
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ wheels = [
 
 [[package]]
 name = "unified-sources"
-version = "0.1.0"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "dlt", extra = ["duckdb"] },
@@ -697,7 +697,7 @@ seznam-sklik = [
 requires-dist = [{ name = "dlt", extras = ["duckdb"], specifier = ">=1.11.0" }]
 
 [package.metadata.requires-dev]
-seznam-sklik = [{ name = "sklik", specifier = ">=1.0.5" }]
+seznam-sklik = [{ name = "sklik", specifier = ">=1.0.6" }]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
### Description

This pull request updates the project dependencies and version:

- Upgraded `pydantic` to v2.11.7.
- Updated `sklik` to v1.0.6.
- Bumped `unified-sources` project version to v0.1.3.
- Adjusted dependency specifications in `uv.lock` and `pyproject.toml`. 

No other changes were made.